### PR TITLE
removed logi_led_ in front of every function

### DIFF
--- a/src/logiledpy/led.py
+++ b/src/logiledpy/led.py
@@ -125,7 +125,7 @@ def logi_led_flash_lighting(
         return False
 
 
-def logi_led_pulse_lighting(
+def pulse_lighting(
     red_percentage, green_percentage, blue_percentage, ms_duration, ms_interval
 ):
     """pulses the lighting color of the combined RGB percentages over the specified millisecond duration and millisecond interval.
@@ -149,7 +149,7 @@ def logi_led_pulse_lighting(
         return False
 
 
-def logi_led_stop_effects():
+def stop_effects():
     """stops the pulse and flash effects."""
     if led_dll:
         return bool(led_dll.LogiLedStopEffects())
@@ -157,7 +157,7 @@ def logi_led_stop_effects():
         return False
 
 
-def logi_led_set_lighting_from_bitmap(bitmap):
+def set_lighting_from_bitmap(bitmap):
     """sets the color of each key in a 21x6 rectangular area specified by the BGRA byte array bitmap. each element corresponds to the physical location of each key.
     note that the color bit order is BGRA rather than standard RGBA bit order. this function only applies to LOGI_DEVICETYPE_PERKEY_RGB devices."""
     if led_dll:
@@ -167,7 +167,7 @@ def logi_led_set_lighting_from_bitmap(bitmap):
         return False
 
 
-def logi_led_set_lighting_for_key_with_scan_code(
+def set_lighting_for_key_with_scan_code(
     key_code, red_percentage, green_percentage, blue_percentage
 ):
     """sets the lighting to the color of the combined RGB percentages for the specified key code. note that RGB ranges from 0-255, but this function ranges from 0-100.
@@ -186,7 +186,7 @@ def logi_led_set_lighting_for_key_with_scan_code(
         return False
 
 
-def logi_led_set_lighting_for_key_with_hid_code(
+def set_lighting_for_key_with_hid_code(
     key_code, red_percentage, green_percentage, blue_percentage
 ):
     """sets the lighting to the color of the combined RGB percentages for the specified key code. note that RGB ranges from 0-255, but this function ranges from 0-100.
@@ -205,7 +205,7 @@ def logi_led_set_lighting_for_key_with_hid_code(
         return False
 
 
-def logi_led_set_lighting_for_key_with_quartz_code(
+def set_lighting_for_key_with_quartz_code(
     key_code, red_percentage, green_percentage, blue_percentage
 ):
     """sets the lighting to the color of the combined RGB percentages for the specified key code. note that RGB ranges from 0-255, but this function ranges from 0-100.
@@ -224,7 +224,7 @@ def logi_led_set_lighting_for_key_with_quartz_code(
         return False
 
 
-def logi_led_set_lighting_for_key_with_key_name(
+def set_lighting_for_key_with_key_name(
     key_name, red_percentage, green_percentage, blue_percentage
 ):
     """sets the lighting to the color of the combined RGB percentages for the specified key name. note that RGB ranges from 0-255, but this function ranges from 0-100.
@@ -243,7 +243,7 @@ def logi_led_set_lighting_for_key_with_key_name(
         return False
 
 
-def logi_led_save_lighting_for_key(key_name):
+def save_lighting_for_key(key_name):
     """saves the current lighting for the specified key name that can be restored later. this function only applies to LOGI_DEVICETYPE_PERKEY_RGB devices."""
     if led_dll:
         key_name = ctypes.c_int(key_name)
@@ -252,7 +252,7 @@ def logi_led_save_lighting_for_key(key_name):
         return False
 
 
-def logi_led_restore_lighting_for_key(key_name):
+def restore_lighting_for_key(key_name):
     """restores the last saved lighting for the specified key name. this function only applies to LOGI_DEVICETYPE_PERKEY_RGB devices."""
     if led_dll:
         key_name = ctypes.c_int(key_name)
@@ -261,7 +261,7 @@ def logi_led_restore_lighting_for_key(key_name):
         return False
 
 
-def logi_led_flash_single_key(
+def flash_single_key(
     key_name,
     red_percentage,
     green_percentage,
@@ -293,7 +293,7 @@ def logi_led_flash_single_key(
         return False
 
 
-def logi_led_pulse_single_key(
+def pulse_single_key(
     key_name,
     red_percentage_start,
     green_percentage_start,
@@ -335,7 +335,7 @@ def logi_led_pulse_single_key(
         return False
 
 
-def logi_led_stop_effects_on_key(key_name):
+def stop_effects_on_key(key_name):
     """stops the pulse and flash effects on a single key."""
     if led_dll:
         key_name = ctypes.c_int(key_name)
@@ -344,7 +344,7 @@ def logi_led_stop_effects_on_key(key_name):
         return False
 
 
-def logi_led_shutdown():
+def shutdown():
     """shutdowns the SDK for the thread."""
     if led_dll:
         return bool(led_dll.LogiLedShutdown())
@@ -352,11 +352,11 @@ def logi_led_shutdown():
         return False
 
 
-def logi_led_get_config_option_number(key, default=0):
+def get_config_option_number(key, default=0):
     """get the default value for the key as a number. if the call fails, the return value is None.
 
     for example, get the low health threshold:
-     logi_led_get_config_option_number('health/low_health_threshold', 20.0)"""
+     get_config_option_number('health/low_health_threshold', 20.0)"""
     if led_dll:
         key = ctypes.c_wchar_p(key)
         default = ctypes.c_double(default)
@@ -365,11 +365,11 @@ def logi_led_get_config_option_number(key, default=0):
     return None
 
 
-def logi_led_get_config_option_bool(key, default=False):
+def get_config_option_bool(key, default=False):
     """get the default value for the key as a bool. if the call fails, the return value is None.
 
     for example, check if the effect is enabled:
-     logi_led_get_config_option_bool('health/pulse_on_low', True)"""
+     get_config_option_bool('health/pulse_on_low', True)"""
     if led_dll:
         key = ctypes.c_wchar_p(key)
         default = ctypes.c_bool(default)
@@ -378,15 +378,15 @@ def logi_led_get_config_option_bool(key, default=False):
     return None
 
 
-def logi_led_get_config_option_color(key, *args):
+def get_config_option_color(key, *args):
     """get the default value for the key as a color. if the call fails, the return value is None.
      note this function can either be called with red_percentage, green_percentage, and blue_percentage or with the logi_led Color object.
 
     for example, get the low health color:
-     logi_led_get_config_option_color('health/pulse_color', 100, 0, 0)
-     logi_led_get_config_option_color('health/pulse_color', Color('red'))
-     logi_led_get_config_option_color('health/pulse_color', Color('#ff0000'))
-     logi_led_get_config_option_color('health/pulse_color', Color(255, 0, 0))"""
+     get_config_option_color('health/pulse_color', 100, 0, 0)
+     get_config_option_color('health/pulse_color', Color('red'))
+     get_config_option_color('health/pulse_color', Color('#ff0000'))
+     get_config_option_color('health/pulse_color', Color(255, 0, 0))"""
     if led_dll:
         key = ctypes.c_wchar_p(key)
         default = None
@@ -418,11 +418,11 @@ def logi_led_get_config_option_color(key, *args):
     return None
 
 
-def logi_led_get_config_option_key_input(key, default=""):
+def get_config_option_key_input(key, default=""):
     """get the default value for the key as a key input. if the call fails, the return value is None.
 
     for example, get the primary ability key input:
-     logi_led_get_config_option_key_input('abilities/primary', 'A')"""
+     get_config_option_key_input('abilities/primary', 'A')"""
     if led_dll:
         key = ctypes.c_wchar_p(key)
         default_key = ctypes.create_string_buffer(256)
@@ -432,12 +432,12 @@ def logi_led_get_config_option_key_input(key, default=""):
     return None
 
 
-def logi_led_set_config_option_label(key, label):
+def set_config_option_label(key, label):
     """set the label for a key.
 
     for example, label 'health/pulse_on_low' as 'Health - Pulse on Low':
-     logi_led_set_config_option_label('health', 'Health')
-     logi_led_set_config_option_label('health/pulse_on_low', 'Pulse on Low')"""
+     set_config_option_label('health', 'Health')
+     set_config_option_label('health/pulse_on_low', 'Pulse on Low')"""
     if led_dll:
         key = ctypes.c_wchar_p(key)
         label = ctypes.c_wchar_p(label)


### PR DESCRIPTION
I find it very tedious and unnecessary to always put a "logi_led_" in front of every function I use.