### PR TITLE
Updated the path for the legacy SDK

### DIFF
--- a/src/logiledpy/led.py
+++ b/src/logiledpy/led.py
@@ -103,7 +103,7 @@ class LEDService:
         if not path_dll:
             bitness = "x86" if platform.architecture()[0] == "32bit" else "x64"
             if self.use_legacy_dll:
-                subpath_dll = f"LGHUB/sdk_legacy_led_{bitness}.dll"
+                subpath_dll = f"LGHUB/sdks/sdk_legacy_led_{bitness}.dll"
             else:
                 subpath_dll = Path(f"/Logitech Gaming Software/SDK/LED/{bitness}/LogitechLed.dll")
 


### PR DESCRIPTION
First of all, thank you for renovating this library for modern use, I really appreciate your work.

Apparently (at least in my version of G HUB) the path for the legacy SDKs has been moved from the root of /LGHUB/ to /LGHUB/sdks/. Not sure in which version this change was made since I recently updated to the newest one. 
There could also be an optional variable like `self.use_legacy_dll_path` to use the old path for the legacy dlls, but I prefer leaving that decision up to the original maintainers.